### PR TITLE
Configure Lightspeed theme and GitHub Pages deployment

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,64 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,11 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3.3"
+
+group :jekyll_plugins do
+  gem "jekyll-feed", "~> 0.17"
+  gem "jekyll-seo-tag", "~> 2.8"
+  gem "jekyll-sitemap", "~> 1.4"
+  gem "jekyll-remote-theme", "~> 0.4"
+  gem "jekyll-paginate-v2", "~> 3.0"
+end

--- a/_config.yml
+++ b/_config.yml
@@ -1,13 +1,9 @@
 # Site Specific Configuration
-sitename: "Bike in Japan"
-name: "Bike in Japan"
 title: Bike in Japan
 description: Mit dem Rad durch Japan
 url: "https://kugeleis.github.io"
 baseurl: ""
-author: 
-  name: kugeleis
-  github: Kugeleis
+author: kugeleis
 
 # Theme and Plugins
 remote_theme: tajacks/lightspeed
@@ -16,16 +12,25 @@ plugins:
   - jekyll-sitemap
   - jekyll-feed
   - jekyll-remote-theme
+  - jekyll-paginate-v2
 
+# Paginate
+pagination:
+  enabled: true
+  per_page: 5
+  sort_field: 'date'
+  sort_reverse: true
 
-# Navigation Links
-nav:
-  - title: Home
-    url: /
-  - title: Posts
-    url: /posts/
-  - title: About
-    url: /about/
+# Category Paginating
+autopages:
+  enabled: true
+  categories:
+    title: 'Posts in category :cat'
+    permalink: '/category/:cat'
+    silent: false
+
+# Exclusions
+exclude: [ 'README.md', 'LICENSE', 'Gemfile', 'Gemfile.lock', '.github' ]
 
 # Keywords - important for SEO
 keywords:

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -1,0 +1,6 @@
+- name: Home
+  link: /
+- name: Posts
+  link: /posts/
+- name: About
+  link: /about/

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,14 @@
+<meta charset="utf-8" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+{% seo %}
+{% if site.keywords or page.tags %}
+<meta name="keywords" content="{% if page.tags %}{{ page.tags | join: ','}}{% else %}{{ site.keywords | join: ',' }}{% endif %}" />
+{% endif %}
+<link rel="icon" type="image/svg+xml" href="{{ '/favicon.svg' | relative_url }}">
+<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/css/styles.css" />
+<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/css/prism.css" />
+<script src="{{ site.baseurl }}/assets/js/prism.js"></script>
+{% if site.analytics.plausible.enabled  %}
+<script defer data-domain="{{ site.analytics.plausible.site_fqdn }}" src="{{ site.analytics.plausible.script_source }}"></script>
+{% endif %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,8 @@
+<div class="header">
+    <h1>{{ site.title }}</h1>
+    <br>
+    <h5><i>{{ site.description }}</i></h5>
+    <br>
+    {% include nav.html %}
+    <hr>
+</div>

--- a/_layouts/autopage_category.html
+++ b/_layouts/autopage_category.html
@@ -1,0 +1,21 @@
+---
+layout: default
+---
+
+<div class="post-summary">
+    <h2>{{ page.title }}</h2>
+    {% for post in paginator.posts %}
+    <span class="post-item">{{ post.date | date: '%Y-%m-%d' }} >> <a href="{{ post.url }}">{{ post.title }}</a><span class="float-right">{{ post.categories | join: ', ' }}</span></span>
+    {% endfor %}
+</div>
+
+<div class="post-nav">
+{% if paginator.total_pages > 1 %}
+{% if paginator.next_page %}
+<a href="{{ paginator.next_page_path | prepend: site.baseurl }}">&lt;- Older</a>
+{% endif %}
+{% if paginator.previous_page %}
+<a href="{{ paginator.previous_page_path | prepend: site.baseurl }}">Newer -&gt;</a>
+{% endif %}
+{% endif %}
+</div>

--- a/_layouts/autopage_collection.html
+++ b/_layouts/autopage_collection.html
@@ -1,0 +1,21 @@
+---
+layout: default
+---
+
+<div class="post-summary">
+    <h2>{{ page.title }}</h2>
+    {% for post in paginator.posts %}
+    <span class="post-item">{{ post.date | date: '%Y-%m-%d' }} >> <a href="{{ post.url }}">{{ post.title }}</a></span>
+    {% endfor %}
+</div>
+
+<div class="post-nav">
+{% if paginator.total_pages > 1 %}
+{% if paginator.next_page %}
+<a href="{{ paginator.next_page_path | prepend: site.baseurl }}">&lt;- Older</a>
+{% endif %}
+{% if paginator.previous_page %}
+<a href="{{ paginator.previous_page_path | prepend: site.baseurl }}">Newer -&gt;</a>
+{% endif %}
+{% endif %}
+</div>

--- a/categories/index.html
+++ b/categories/index.html
@@ -1,0 +1,15 @@
+---
+layout: default
+title: Categories
+---
+
+<h2>Categories</h2>
+{% for category in site.categories %}
+    <h3 class="category-header"><b>{{category | first}}</b></h3>
+        {% for post in category[1] limit:3 %}
+        <span class="post-item">{{ post.date | date: '%Y-%m-%d' }} >> <a href="{{ post.url }}">{{ post.title }}</a></span>
+        {% endfor %}
+<div class="category-all-nav">
+    <h4>See all posts in {{category | first}} ({{category[1] | size}}) <a href="/category/{{category | first | downcase }}/">&gt;&gt;</a></h4>
+</div>
+{% endfor %}

--- a/custom-head.html
+++ b/custom-head.html
@@ -1,2 +1,0 @@
-{% seo %}
-<link rel="icon" type="image/svg+xml" href="{{ '/favicon.svg' | relative_url }}">

--- a/index.md
+++ b/index.md
@@ -3,8 +3,6 @@ layout: default
 title: Startseite
 ---
 
-*Bike in Japan* - mit dem Fahrrad durch Japan
-
 ## Neue Artikel
 
 {% for post in site.posts %}

--- a/posts/index.html
+++ b/posts/index.html
@@ -1,0 +1,22 @@
+---
+layout: default
+title: Posts
+pagination:
+    enabled: true
+---
+
+<h2>Posts</h2>
+{% for post in paginator.posts %}
+<span class="post-item"><span class="mobile-hide"> {{ post.date | date: '%Y-%m-%d' }} >> </span><a href="{{ post.url }}">{{ post.title }}</a><span class="float-right mobile-hide">{{ post.categories | join: ', ' }}</span></span>
+{% endfor %}
+
+<div class="post-nav">
+{% if paginator.total_pages > 1 %}
+{% if paginator.next_page %}
+<a href="{{ paginator.next_page_path | prepend: site.baseurl }}">&lt;- Older</a>
+{% endif %}
+{% if paginator.previous_page %}
+<a href="{{ paginator.previous_page_path | prepend: site.baseurl }}">Newer -&gt;</a>
+{% endif %}
+{% endif %}
+</div>


### PR DESCRIPTION
I have correctly configured the Jekyll site to work with the 'lightspeed' theme and GitHub Pages. 

Key changes:
1.  **Plugin Support**: Added `jekyll-paginate-v2` and configured it in `_config.yml`.
2.  **Navigation**: Moved navigation to `_data/nav.yml` using the keys (`name`, `link`) expected by the theme.
3.  **Header Customization**: Overrode `_includes/header.html` to use dynamic site title and description instead of hardcoded theme values.
4.  **Favicon & Head**: Overrode `_includes/head.html` to support the SVG favicon and merged custom SEO logic.
5.  **GitHub Pages Compatibility**: Created a `Gemfile` and a GitHub Actions workflow (`.github/workflows/jekyll.yml`) to build and deploy the site. This is necessary because `jekyll-paginate-v2` is not supported by the default GitHub Pages builder.
6.  **Missing Pages & Layouts**: Added `posts/index.html`, `categories/index.html`, and missing layouts for category autopages to ensure a complete and functional blog experience.
7.  **Cleanup**: Removed redundant files and duplicate text on the homepage.

The site was verified locally with a successful Jekyll build and visual screenshots of the homepage and posts list.

---
*PR created automatically by Jules for task [1440300748151070273](https://jules.google.com/task/1440300748151070273) started by @Kugeleis*