### PR TITLE
Add medium-zoom to blog posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -26,3 +26,8 @@ layout: default
 <div class="post-content">
 {{ content }}
 </div>
+
+<script src="https://cdn.jsdelivr.net/npm/medium-zoom@1/dist/medium-zoom.min.js"></script>
+<script>
+  mediumZoom('.post-content img');
+</script>


### PR DESCRIPTION
Integrated the `medium-zoom` library to enhance the user experience by allowing images in blog posts to be zoomed upon clicking. 

Key changes:
- Modified `_layouts/post.html` to include the `medium-zoom` script from jsDelivr.
- Added a script block to initialize `medium-zoom` on all `img` elements within the `.post-content` container.
- Verified the functionality using a Playwright script that simulates user clicks and confirms the presence of the zoom overlay.

---
*PR created automatically by Jules for task [3550574484439211963](https://jules.google.com/task/3550574484439211963) started by @Kugeleis*